### PR TITLE
Font name duplication check added for mono

### DIFF
--- a/Source/Deps/PixelFarm.Drawing.Platforms/PixelFarm.Drawing.Gdi/Implementation/FontStore.cs
+++ b/Source/Deps/PixelFarm.Drawing.Platforms/PixelFarm.Drawing.Gdi/Implementation/FontStore.cs
@@ -212,7 +212,10 @@ namespace PixelFarm.Drawing.WinGdi
 
             foreach (var family in System.Drawing.FontFamily.Families)
             {
-                _existingFontFamilies.Add(family.Name, family);
+                if (_existingFontFamilies.ContainsKey (family.Name) == false)
+                {
+                    _existingFontFamilies.Add (family.Name, family);
+                }
             }
         }
 


### PR DESCRIPTION
fix for
https://github.com/prepare/HTML-Renderer/issues/7
